### PR TITLE
Pin yaml to >=2.8.3 via npm overrides to fix CVE stack overflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7280,18 +7280,6 @@
       "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
       "license": "MIT"
     },
-    "node_modules/yaml-language-server/node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.10"
+  },
+  "overrides": {
+    "yaml": ">=2.8.3"
   }
 }


### PR DESCRIPTION
Adds an npm `overrides` entry for `yaml` to enforce a minimum of 2.8.3, patching the transitive dependency introduced by @astrojs/check whose semver range (^2.3.4) allowed the vulnerable 2.0.0–2.8.2 range. The compose/resolve phase used unbounded recursion, letting ~2–10 KB of deeply-nested YAML exhaust the call stack with a RangeError.

https://claude.ai/code/session_011vUhmRByT6YkY6Cyz34Lqh